### PR TITLE
fix: fixes #12 to show gas prices down to atomic wei

### DIFF
--- a/src/chain/gas.ts
+++ b/src/chain/gas.ts
@@ -87,8 +87,27 @@ export class Gas {
 	}
 
 	public static gasPriceToString(price: BigNumber): string {
-		const units = price.lt(utils.parseUnits('1', 'gwei')) ? 'mwei' : 'gwei'
-		return `${Number(utils.formatUnits(price, units)).toFixed(3)} ${units}`
+		const unitBreakdown = [
+			{ price: utils.parseUnits('1', 'wei'), units: 'wei' },
+			{ price: utils.parseUnits('1', 'kwei'), units: 'wei' },
+			{ price: utils.parseUnits('1', 'mwei'), units: 'kwei' },
+			{ price: utils.parseUnits('1', 'gwei'), units: 'mwei' },
+		]
+
+		let pu = unitBreakdown.find((pu) => {
+			return price.lt(pu.price)
+		})
+		if (!pu) pu = { price: BigNumber.from(0), units: 'gwei' }
+
+		// Reduce precision based on magnitude by dropping rightmost decimal places
+		let n = utils.formatUnits(price, pu.units)
+		const dot = n.indexOf('.')
+		if (dot > 0) {
+			if (dot < 3) n = n.slice(0, 4)
+			else n = n.slice(0, dot)
+		}
+
+		return `${n} ${pu.units}`
 	}
 }
 


### PR DESCRIPTION
The lookup variable is called "pu" for a double-meaning. It's the "price/unit" and the code doesn't really smell very good because the unitBreakdown array is being built on every invocation. Fixes https://github.com/rndlabs/monSI/issues/12