### PR TITLE
fix: correct overlay validator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,18 +77,20 @@ function cliParseInt(value: string, dummyPrevious: unknown): number {
 }
 
 function cliParseOverlay(overlay: string, previous: string[]): string[] {
-	// Be forgiving to the user since /addresses doesn't include the 0x
-	if (overlay.slice(0, 2) != '0x') overlay = '0x' + overlay
 	try {
 		// use ethers to validate the overlay address
-		if (utils.arrayify(overlay).length != 32)
+		const bytes = utils.arrayify(overlay, { allowMissingPrefix: true })
+		if (bytes.length != 32) {
 			throw new Error('Invalid overlay length')
+		} else {
+			if (!previous) previous = []
+			// for ensuring consistent `0x` prefix
+			previous.push(utils.hexlify(bytes))
+			return previous
+		}
 	} catch (e) {
 		throw new InvalidOptionArgumentError('Not a valid overlay.')
 	}
-	if (!previous) previous = []
-	previous[previous.length] = overlay
-	return previous
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,16 +76,19 @@ function cliParseInt(value: string, dummyPrevious: unknown): number {
 	return parsedValue
 }
 
-function cliParseOverlay(value: string[]): string[] {
-	for (const overlay of value) {
-		try {
-			// use ethers to validate the overlay address
-			utils.parseBytes32String(utils.arrayify(overlay))
-		} catch (e) {
-			throw new InvalidOptionArgumentError('Not a valid overlay.')
-		}
+function cliParseOverlay(overlay: string, previous: string[]): string[] {
+	// Be forgiving to the user since /addresses doesn't include the 0x
+	if (overlay.slice(0, 2) != '0x') overlay = '0x' + overlay
+	try {
+		// use ethers to validate the overlay address
+		if (utils.arrayify(overlay).length != 32)
+			throw new Error('Invalid overlay length')
+	} catch (e) {
+		throw new InvalidOptionArgumentError('Not a valid overlay.')
 	}
-	return value
+	if (!previous) previous = []
+	previous[previous.length] = overlay
+	return previous
 }
 
 /**


### PR DESCRIPTION
The validator is passed a string and the previous array of strings due to the [...] in the declaration.  It should return the updated array of strings so that all values are in the array when the command line parse is complete.  utils.parseBytes32String requires a null terminated binary array, so it won't work for overlay validation.