### PR TITLE
StakeRegistry log processing

### DIFF
--- a/src/chain/sync.ts
+++ b/src/chain/sync.ts
@@ -239,10 +239,16 @@ export class ChainSync {
 			this.stakeRegistry.filters[
 				'StakeUpdated(bytes32,uint256,address,uint256)'
 			](),
-			(stakeId, amount, owner, round) => {
-				// if (this._state == State.RUNNING)
+			async (overlay, stakeAmount, owner, lastBlockUpdated, event) => {
+				if (this._state == State.RUNNING) {
+					const block = await this.provider.getBlock(event.blockNumber)
+					game.stakeUpdated(overlay, owner, stakeAmount, {
+						blockNo: event.blockNumber,
+						blockTimestamp: block.timestamp,
+					})
+				}
 				Logging.showLogError(
-					`StakeUpdated event: ${stakeId}, ${amount}, ${owner}, ${round}`
+					`StakeUpdated event: ${overlay}, ${stakeAmount}, ${owner}, ${lastBlockUpdated}`
 				)
 			}
 		)

--- a/src/types/entities/schelling.ts
+++ b/src/types/entities/schelling.ts
@@ -282,6 +282,12 @@ export class SchellingGame {
 		player.updateStake(block, amount)
 	}
 
+	public stakeSlashed(overlay: string, amount: BigNumber, block: BlockDetails) {
+		// update player state
+		const player = this.getOrCreatePlayer(overlay, undefined, block)
+		player.slash(block, amount)
+	}
+
 	// --- singleton method
 
 	public static getInstance(): SchellingGame {


### PR DESCRIPTION
This PR:

1. Implements multiple topic (_or_) `getLogs` query for the `StakeRegistry` events `StakeUpdated` and `StakeSlashed` in order to calculate the user's present _stake_ (fixes #5)
2. Connects the `StakeUpdated` subscription with the game for processing updated stakes (fixes #10)