### PR TITLE
feat: track and display total slashed amount and numerous UI improvements

### DIFF
--- a/src/chain/sync.ts
+++ b/src/chain/sync.ts
@@ -161,7 +161,7 @@ export class ChainSync {
 		await this.processStakeLog(stakeLogs)
 		const elapsed = Date.now() - start
 		Logging.showLogError(
-			`Loaded ${stakeLogs.length} StakeRegistry logs in ${elapsed}ms`
+			`Loaded ${stakeLogs.length} StakeRegistry logs in ${elapsed / 1000}s`
 		)
 
 		// 2. Process all `commit`, `reveal`, and `claim` transactions to the Redistribution contract.
@@ -186,7 +186,12 @@ export class ChainSync {
 			)
 
 			if (block.number % 100 == 0)
-				Logging.showError(`Sync: Processing block ${block.number}`, 'sync')
+				Logging.showError(
+					`Sync: Processing block ${block.number}/${
+						endingBlock ? endingBlock : this.tip
+					}`,
+					'sync'
+				)
 
 			await this.blockHandler(block)
 
@@ -201,7 +206,9 @@ export class ChainSync {
 		} while (this.lastBlock.blockNo < this.tip)
 		const elapsed2 = Date.now() - start2
 		Logging.showLogError(
-			`Sync: Complete from block ${startFromBlock} to ${this.lastBlock.blockNo} in ${elapsed2}ms`
+			`Sync: Complete from block ${startFromBlock} to ${
+				this.lastBlock.blockNo
+			} in ${elapsed2 / 1000}s`
 		)
 
 		// for (let i = this.lastBlock; i <= nowBlockNumber; i++) {
@@ -257,7 +264,7 @@ export class ChainSync {
 		this.bzzToken.on(this.bzzToken.filters.Transfer(), (from, to, amount) => {
 			// if (this._state == State.RUNNING)
 			Logging.showLogError(
-				`${shortBZZ(amount)} gBZZ from ${fmtAccount(from)} to ${fmtAccount(to)}`
+				`${shortBZZ(amount)} from ${fmtAccount(from)} to ${fmtAccount(to)}`
 			)
 		})
 
@@ -266,7 +273,7 @@ export class ChainSync {
 			(owner, spender, value) => {
 				// if (this._state == State.RUNNING)
 				Logging.showLogError(
-					`${shortBZZ(value)} gBZZ Approved from ${fmtAccount(
+					`${shortBZZ(value)} Approved from ${fmtAccount(
 						owner
 					)} to ${fmtAccount(spender)}`
 				)
@@ -287,7 +294,7 @@ export class ChainSync {
 			const offsetLine = game.size + 1 // Keep room for the getRpcUrl
 			Ui.getInstance().lineSetterCallback(BOXES.ALL_PLAYERS)(
 				offsetLine,
-				`{center}${config.name} getGasPrice{/center}`,
+				`{center}${config.chain.name} getGasPrice{/center}`,
 				-1
 			)
 			Ui.getInstance().lineSetterCallback(BOXES.ALL_PLAYERS)(

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,12 @@ import { ChainSync } from './chain'
 
 export type ChainConfig = {
 	chain: {
+		name: string
 		secondsPerBlock: number
+	}
+	units: {
+		BZZ: string
+		ETH: string
 	}
 	game: {
 		blocksPerRound: number
@@ -18,17 +23,23 @@ export type ChainConfig = {
 		stakeRegistry: string
 		bzzToken: string
 		postageStamp: string
+		priceOracle: string
 	}
 }
 
 export type Configs = {
 	[chainId: number]: ChainConfig
 }
-
+//  Note: contract addresses come from https://github.com/ethersphere/bee/blob/master/pkg/config/chain.go
 export const chainConfig: Configs = {
 	'5': {
 		chain: {
+			name: 'goerli',
 			secondsPerBlock: 12,
+		},
+		units: {
+			BZZ: 'gBZZ',
+			ETH: 'gETH',
 		},
 		game: {
 			blocksPerRound: 152,
@@ -41,12 +52,18 @@ export const chainConfig: Configs = {
 			stakeRegistry: '0x18391158435582D5bE5ac1640ab5E2825F68d3a4',
 			bzzToken: '0x2aC3c1d3e24b45c6C310534Bc2Dd84B5ed576335',
 			postageStamp: '0x7aAC0f092F7b961145900839Ed6d54b1980F200c',
+			priceOracle: '0x0c9de531dcb38b758fe8a2c163444a5e54ee0db2', // "goerliContractAddress" in pkg/config/chain.go
 		},
 	},
 	'100': {
 		// TODO: Correct these values once gnosis is deployed
 		chain: {
+			name: 'gnosis',
 			secondsPerBlock: 5,
+		},
+		units: {
+			BZZ: 'xBZZ',
+			ETH: 'xdai', // Is it xdai, xDai, or xDAI
 		},
 		game: {
 			blocksPerRound: 152,
@@ -58,6 +75,7 @@ export const chainConfig: Configs = {
 			stakeRegistry: '0x18391158435582D5bE5ac1640ab5E2825F68d3a4', // wrong
 			bzzToken: '0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da', // correct
 			postageStamp: '0x6a1A21ECA3aB28BE85C7Ba22b2d6eAE5907c900E', // correct
+			priceOracle: '0x0FDc5429C50e2a39066D8A94F3e2D2476fcc3b85', // correct, "xdaiContractAddress" in pkg/config/chain.go
 		},
 	},
 }
@@ -76,6 +94,10 @@ export default class Config {
 
 	static get contracts(): ChainConfig['contracts'] {
 		return Config.chainConfig[Config.chainId].contracts
+	}
+
+	static get units(): ChainConfig['units'] {
+		return Config.chainConfig[Config.chainId].units
 	}
 
 	static get game(): ChainConfig['game'] {

--- a/src/lib/formatText.ts
+++ b/src/lib/formatText.ts
@@ -23,10 +23,14 @@ export function leftId(id: string, n: number) {
 
 export function fmtAccount(acct: string, n = 12): string {
 	acct = acct.toLowerCase()
-	if (acct == config.contracts.redistribution) return 'Redistribution'
-	if (acct == config.contracts.stakeRegistry) return 'StakeRegistry'
-	if (acct == config.contracts.bzzToken) return 'gBZZToken'
-	if (acct == config.contracts.postageStamp) return 'PostageStamp'
+	if (acct == config.contracts.redistribution.toLowerCase())
+		return 'Redistribution'
+	if (acct == config.contracts.stakeRegistry.toLowerCase())
+		return 'StakeRegistry'
+	if (acct == config.contracts.bzzToken.toLowerCase())
+		return config.units.BZZ + 'Token'
+	if (acct == config.contracts.postageStamp.toLowerCase()) return 'PostageStamp'
+	if (acct == config.contracts.priceOracle.toLowerCase()) return 'PriceOracle'
 
 	let r = leftId(acct, n)
 	if (SchellingGame.getInstance().isMyAccount(acct))

--- a/src/lib/formatUi.ts
+++ b/src/lib/formatUi.ts
@@ -56,6 +56,7 @@ export function colorDelta(
 	}
 
 	const delta = value.sub(lastValue)
+	lastValues[name] = value
 	if (!delta.eq(0)) {
 		return ' (' + colorValue(delta, fmtRtn, options) + ')'
 	}

--- a/src/lib/formatUnits.ts
+++ b/src/lib/formatUnits.ts
@@ -2,11 +2,13 @@
  * Formats a string of numbers into a string with SI suffixes.
  */
 
+import config from '../config'
 import { BigNumber, utils } from 'ethers'
 
 export type FormatUnitOptions = {
 	precision?: number
 	showPlus?: boolean
+	suppressUnits?: boolean
 }
 
 export function formatSi(num: BigNumber, options?: FormatUnitOptions): string {
@@ -68,8 +70,11 @@ export function shortCurrency(
 		n = n.mul(-1)
 	}
 
-	const resultFmt = (precision: number) =>
-		Number(utils.formatUnits(n, decimals)).toFixed(precision) + ' ' + symbol
+	const resultFmt = (precision: number) => {
+		let rf = Number(utils.formatUnits(n, decimals)).toFixed(precision)
+		if (!options || !options.suppressUnits) rf += ' ' + symbol
+		return rf
+	}
 
 	if (n.lt(ONE.div(100))) return formatSi(n, options)
 	else if (n.gte(ONE.mul(100))) result = resultFmt(0)
@@ -83,7 +88,7 @@ export function shortCurrency(
 }
 
 export function shortBZZ(n: BigNumber, options?: FormatUnitOptions) {
-	return shortCurrency(n, 16, 'BZZ', options)
+	return shortCurrency(n, 16, config.units.BZZ, options)
 }
 
 export function shortETH(n: BigNumber, options?: FormatUnitOptions) {

--- a/src/types/entities/round.ts
+++ b/src/types/entities/round.ts
@@ -1,7 +1,7 @@
 import { BigNumber, BigNumberish } from 'ethers'
 import { BlockDetails } from '../../chain'
 import config from '../../config'
-import { fmtOverlay, formatSi } from '../../lib'
+import { fmtOverlay, shortBZZ } from '../../lib'
 import { SchellingGame } from './schelling'
 import { Ui, BOXES } from './ui'
 
@@ -84,7 +84,7 @@ export class Round {
 			r += ` ^${this.claim.depth}`
 			r +=
 				' {green-fg}' +
-				formatSi(this.claim.amount, { showPlus: true }) +
+				shortBZZ(this.claim.amount, { showPlus: true, suppressUnits: true }) +
 				'{/green-fg}'
 		} else if (this.unclaimed) {
 			r += ' {magenta-fg}UNCLAIMED{/magenta-fg}'


### PR DESCRIPTION
comment where contract addresses are sourced from in config
add priceOracle contract address to config
configure units for BZZ and ETH and name for chain

use configured BZZ units in shortBZZ
correct fmtAccount to properly compare contract addresses (toLowerCase) & add PriceOracle
correct colorDelta to actually remember the previous value to show true delta per invocation
use shortBZZ for round rewards and player deltas instead of formatSI and support options.suppressUnits

catchup block iteration log shows target end point
use chain name in getGasPrice title (was showing "Config")
change elapsed time display of 2 catchup phases from ms to s (but still include up to 3 decimals)

remove redundant token name from bzzToken contract log subscription log, both Transfer and Approve
add block number to freeze, update, and slash stake logs
remove extra space in slash log

shorten hash display in Round Players from 10*2 to 6*2 (makes room for stake w/units)

accumulate and display (negative red) total observed applied slash
