### PR TITLE
fix: prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 /dist
 /test/data
+/src/types/contracts
+.github
+README.md
 package-lock.json


### PR DESCRIPTION
This PR fixes the prettierignore to ignore github CI/CD YAML, readmes and auto-generated contract classes.