### PR TITLE
fix: release cicd

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,18 @@
+{
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ],
+  "preset": "angular"
+}

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,11 @@
+import type { UserConfig } from '@commitlint/types'
+
+const Configuration: UserConfig = {
+	/*
+	 * Resolve and load @commitlint/config-conventional from node_modules.
+	 * Referenced packages must be installed
+	 */
+	extends: ['@commitlint/config-conventional'],
+}
+
+module.exports = Configuration


### PR DESCRIPTION
This PR fixes the release cycle by adding missing `.releaserc` and commitlint configuration files.