### PR TITLE
chore: min node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# .npmrc
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -89,5 +89,9 @@
 	"eslintIgnore": [
 		"build/*"
 	],
-	"type": "module"
+	"type": "module",
+	"engines": {
+		"npm": ">=8.0.0 <9.0.0",
+		"node": ">=16.14.0"
+	}
 }


### PR DESCRIPTION
This PR enforces version requirements around `node` / `npm`.