### PR TITLE
cicd: node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Install dependencies
         run: npx ci
       - name: Install semantic-release extra plugins


### PR DESCRIPTION
This PR:

1. Fixes the `node` version used in CI/CD.